### PR TITLE
Update the version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-template-nimble",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "keywords": [
     "react",
     "create-react-app",


### PR DESCRIPTION
## What happened 

We're going to tag the previous version of the template as `1.0.0` and this version as `2.0.0` so the version specified on the [previous pull request](https://github.com/nimblehq/react-templates/pull/12) is incorrect

## Insight

N/A

## Proof Of Work 💪

N/A