### PR TITLE
Add ESLint and Prettier

### DIFF
--- a/template.json
+++ b/template.json
@@ -9,10 +9,25 @@
       "@types/react-dom": "17.0.0",
       "@types/jest": "26.0.15",
       "typescript": "4.1.2",
-      "web-vitals": "1.0.1"
+      "web-vitals": "1.0.1",
+      "eslint": "7.25.0",
+      "prettier": "2.2.1",
+      "@nimbl3/eslint-config-nimbl3": "2.1.1",
+      "eslint-plugin-prettier": "3.4.0",
+      "eslint-config-prettier": "8.3.0",
+      "eslint-plugin-import": "2.22.1",
+      "eslint-plugin-jsx-a11y": "6.4.1",
+      "eslint-plugin-react": "7.23.2",
+      "eslint-plugin-react-hooks": "4.2.0",
+      "@typescript-eslint/eslint-plugin": "4.22.1",
+      "@typescript-eslint/parser": "4.22.1"
+    },
+    "scripts": {
+      "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+      "lint:fix": "eslint ./src --ext .js,.jsx,.ts,.tsx --fix"
     },
     "eslintConfig": {
-      "extends": ["react-app", "react-app/jest"]
+      "extends": ["react-app"]
     }
   }
 }

--- a/template.json
+++ b/template.json
@@ -19,6 +19,7 @@
       "eslint-plugin-jsx-a11y": "6.4.1",
       "eslint-plugin-react": "7.23.2",
       "eslint-plugin-react-hooks": "4.2.0",
+      "eslint-plugin-jest": "24.3.6",
       "@typescript-eslint/eslint-plugin": "4.22.1",
       "@typescript-eslint/parser": "4.22.1"
     },
@@ -26,9 +27,6 @@
       "lint": "eslint ./src --ext .ts,.tsx",
       "lint:fix": "eslint ./src --ext .ts,.tsx --fix",
       "prettier": "prettier \"src/**/*.{ts,html}\" --write"
-    },
-    "eslintConfig": {
-      "extends": ["react-app"]
     }
   }
 }

--- a/template.json
+++ b/template.json
@@ -23,8 +23,9 @@
       "@typescript-eslint/parser": "4.22.1"
     },
     "scripts": {
-      "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-      "lint:fix": "eslint ./src --ext .js,.jsx,.ts,.tsx --fix"
+      "lint": "eslint ./src --ext .ts,.tsx",
+      "lint:fix": "eslint ./src --ext .ts,.tsx --fix",
+      "prettier": "prettier \"src/**/*.{ts,html}\" --write"
     },
     "eslintConfig": {
       "extends": ["react-app"]

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -8,9 +8,20 @@ module.exports = {
   extends: [
     '@nimbl3/eslint-config-nimbl3',
     'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:import/errors',
-    'prettier'
+    'plugin:prettier/recommended'
+  ],
+  overrides: [
+    {
+      files: 'src/tests/**/*.test.ts',
+      extends: [
+        'plugin:jest/recommended',
+        'plugin:jest/style'
+      ]
+    }
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -20,7 +31,6 @@ module.exports = {
       jsx: true
     }
   },
-  plugins: ['react', '@typescript-eslint', 'prettier', 'react-hooks'],
   rules: {
     'max-len': ['error', { code: 120 }],
     'react-hooks/rules-of-hooks': 'error',

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,0 +1,81 @@
+module.exports = {
+  env: {
+    es6: true,
+    browser: true,
+    node: true,
+    jest: true
+  },
+  extends: [
+    '@nimbl3/eslint-config-nimbl3',
+    'plugin:react/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:import/errors',
+    'prettier'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['react', '@typescript-eslint', 'prettier', 'react-hooks'],
+  rules: {
+    'max-len': ['error', { code: 120 }],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    'react/jsx-filename-extension': [2, { extensions: ['.tsx'] }],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal'],
+        pathGroups: [
+          {
+            pattern: 'react*',
+            group: 'external',
+            position: 'before'
+          },
+          {
+            pattern: 'css/*|*.scss|*.svg|.png',
+            group: 'internal',
+            position: 'after'
+          }
+        ],
+        pathGroupsExcludedImportTypes: ['react'],
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true
+        }
+      }
+    ],
+    'import/extensions': [
+      'error',
+      'never',
+      {
+        scss: 'always',
+        svg: 'always',
+        png: 'always',
+        json: 'always',
+        spec: 'always'
+      }
+    ],
+    'no-use-before-define': 'off',
+    'no-unused-vars': 'off',
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-use-before-define': ['error'],
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.ts', '.tsx']
+      }
+    }
+  }
+}

--- a/template/.prettierrc
+++ b/template/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"semi": false,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 120
+}

--- a/template/README.md
+++ b/template/README.md
@@ -1,43 +1,33 @@
-# Getting Started with Create React App
+# React App
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project was bootstrapped with [Nimble React template](https://github.com/nimblehq/react-templates).
 
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm start`
+`yarn start` : Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+`yarn test`: Launches the test runner in the interactive watch mode. See the section about 
+[running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+`yarn build`: Builds the app for production to the `build` folder. It correctly bundles React in production mode and
+optimizes the build for the best performance. The build is minified and the filenames include the hashes. Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+`yarn eject`: If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This
+command will remove the single build dependency from your project. Instead, it will copy all the configuration files 
+and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them.
+All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them.
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+`yarn lint`: Run ESLint in the project.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+`yarn lint:fix`: Fix auto-correctable ESLint errors in the project.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+`yarn prettier`: Run Prettier in the project.
 
 ## Learn More
 

--- a/template/src/App.test.tsx
+++ b/template/src/App.test.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import App from './App'
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+  render(<App />)
+  const linkElement = screen.getByText(/learn react/i)
+  expect(linkElement).toBeInTheDocument()
+})

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import React from 'react'
 
-function App() {
+import logo from './logo.svg'
+import './App.css'
+
+function App(): JSX.Element {
   return (
     <div className="App">
       <header className="App-header">
@@ -10,17 +11,12 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a className="App-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer">
           Learn React
         </a>
       </header>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -1,17 +1,18 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import './index.css'
+import App from './App'
+import reportWebVitals from './reportWebVitals'
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
   document.getElementById('root')
-);
+)
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+reportWebVitals()

--- a/template/src/reportWebVitals.ts
+++ b/template/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from 'web-vitals'
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+      getCLS(onPerfEntry)
+      getFID(onPerfEntry)
+      getFCP(onPerfEntry)
+      getLCP(onPerfEntry)
+      getTTFB(onPerfEntry)
+    })
   }
-};
+}
 
-export default reportWebVitals;
+export default reportWebVitals

--- a/template/src/setupTests.ts
+++ b/template/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'


### PR DESCRIPTION
Task card: https://github.com/nimblehq/react-templates/projects/2#card-59674982

## What happened
Add ESLint and Prettier to the template.
 
## Insight
- Added ESLint with configurations from [@nimblehq/eslint-config-nimble](https://github.com/nimblehq/eslint-config-nimble)
- Added React, Typescript, JSX, and import plugins to ESLint
- Added prettier
- Added scripts to run lint and prettier
 
## Proof Of Work
- Test locally by running
`npx create-react-app my-react-app --template file:<path-to-the-template>`

- Run the command `yarn lint` after creating the project. There will be no linting errors.
![image](https://user-images.githubusercontent.com/14927672/117396526-f2f43300-af1b-11eb-8b74-338f781b16c2.png)

- Run the command `yarn lint:fix` if there is a linting error.
![image](https://user-images.githubusercontent.com/14927672/117118988-48f99700-adb3-11eb-84aa-10fe940a94d0.png)

- Run the command `yarn prettier` if we need to format a page.
![image](https://user-images.githubusercontent.com/14927672/117119024-557def80-adb3-11eb-98fd-1f1a0ea1a551.png)
