### PR TITLE
[#33] Add test coverage and merge coverage report from Jest and Cypress

### DIFF
--- a/template.json
+++ b/template.json
@@ -36,7 +36,7 @@
       "stylelint-config-property-sort-order-smacss": "7.1.0"
     },
     "scripts": {
-      "start": "react-scripts -r @cypress/instrument-cra start start",
+      "start": "react-scripts -r @cypress/instrument-cra start",
       "test:coverage": "react-scripts test --coverage --watchAll=false && yarn cypress:run && node ./scripts/coverage-merge.js && nyc report",
       "lint": "eslint ./src ./cypress --ext .ts,.tsx",
       "lint:fix": "eslint ./src ./cypress --ext .ts,.tsx --fix",

--- a/template.json
+++ b/template.json
@@ -1,6 +1,7 @@
 {
   "package": {
     "dependencies": {
+      "@cypress/code-coverage": "3.9.11",
       "@testing-library/jest-dom": "5.11.4",
       "@testing-library/react": "11.1.0",
       "@testing-library/user-event": "12.1.10",
@@ -12,7 +13,7 @@
       "typescript": "4.1.2",
       "web-vitals": "1.0.1",
       "axios": "0.21.1",
-      "cypress": "7.4.0",
+      "cypress": "8.7.0",
       "cypress-react-selector": "2.3.6",
       "eslint": "7.25.0",
       "prettier": "2.2.1",
@@ -35,6 +36,8 @@
       "stylelint-config-property-sort-order-smacss": "7.1.0"
     },
     "scripts": {
+      "start": "react-scripts -r @cypress/instrument-cra start start",
+      "test:coverage": "react-scripts test --coverage --watchAll=false && yarn cypress:run && node ./scripts/coverage-merge.js && nyc report",
       "lint": "eslint ./src ./cypress --ext .ts,.tsx",
       "lint:fix": "eslint ./src ./cypress --ext .ts,.tsx --fix",
       "stylelint": "stylelint '**/*.scss'",
@@ -43,6 +46,18 @@
       "codebase:fix": "yarn lint:fix && yarn stylelint:fix",
       "cypress:run": "cypress run",
       "cypress:open": "cypress open"
+    },
+    "jest": {
+      "collectCoverageFrom": ["src/**/*.{js,jsx,ts,tsx}", "!src/**/*.d.ts"],
+      "coverageReporters": ["json"]
+    },
+    "nyc": {
+      "report-dir": "coverage/cypress",
+      "exclude": ["src/reportWebVitals.ts"],
+      "excludeAfterRemap": true
+    },
+    "devDependencies": {
+      "@cypress/instrument-cra": "1.4.0"
     }
   }
 }

--- a/template/README.md
+++ b/template/README.md
@@ -6,10 +6,11 @@ This project was bootstrapped with [Nimble React template](https://github.com/ni
 
 In the project directory, you can run:
 
-`yarn start` : Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+`yarn start`: Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-`yarn test`: Launches the test runner in the interactive watch mode. See the section about 
-[running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+`yarn test`: Launches the test runner in the interactive watch mode. See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+`yarn test:coverage`: Both Unit Tests (Jest) and UI Tests (cypress) generate test coverage analytics. The below command runs all tests and merges both coverage files into a single report.
 
 `yarn build`: Builds the app for production to the `build` folder. It correctly bundles React in production mode and
 optimizes the build for the best performance. The build is minified and the filenames include the hashes. Your app is ready to be deployed!
@@ -17,8 +18,7 @@ optimizes the build for the best performance. The build is minified and the file
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
 `yarn eject`: If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This
-command will remove the single build dependency from your project. Instead, it will copy all the configuration files 
-and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them.
+command will remove the single build dependency from your project. Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them.
 All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them.
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**

--- a/template/README.md
+++ b/template/README.md
@@ -12,6 +12,8 @@ In the project directory, you can run:
 
 `yarn test:coverage`: Both Unit Tests (Jest) and UI Tests (cypress) generate test coverage analytics. The below command runs all tests and merges both coverage files into a single report.
 
+> Use the `.nyc_output/out.json` artefact in your CI/CD pipeline to reuse the code coverage data.
+
 `yarn build`: Builds the app for production to the `build` folder. It correctly bundles React in production mode and
 optimizes the build for the best performance. The build is minified and the filenames include the hashes. Your app is ready to be deployed!
 

--- a/template/cypress/plugins/index.ts
+++ b/template/cypress/plugins/index.ts
@@ -1,3 +1,15 @@
-/* eslint-disable */
+import browserify from '@cypress/browserify-preprocessor'
+import task from '@cypress/code-coverage/task'
 
-module.exports = (on, config) => {};
+module.exports = (on, config) => {
+  task(on, config)
+
+  on(
+    'file:preprocessor',
+    browserify({
+      typescript: require.resolve('typescript')
+    })
+  )
+
+  return config
+}

--- a/template/cypress/support/index.ts
+++ b/template/cypress/support/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 
+import '@cypress/code-coverage/support'
 import './commands'
 import './configure-testing-library'
 import './component-selector'

--- a/template/gitignore
+++ b/template/gitignore
@@ -6,7 +6,10 @@
 .pnp.js
 
 # testing
+/cypress/screenshots
+/cypress/videos
 /coverage
+.nyc_output
 
 # production
 /build

--- a/template/scripts/coverage-merge.js
+++ b/template/scripts/coverage-merge.js
@@ -1,0 +1,26 @@
+/**
+ * This script merges the coverage reports from Cypress and Jest into a single one,
+ * inside the "coverage" folder
+ */
+const { execSync } = require('child_process')
+const fs = require('fs-extra')
+const COVERAGE_JEST_FOLDER = 'coverage'
+const COVERAGE_CYPRESS_FOLDER = 'coverage/cypress'
+const REPORTS_FOLDER = 'coverage/reports'
+const FINAL_OUTPUT_FOLDER = 'coverage/merged'
+const run = (commands) => {
+  commands.forEach((command) => execSync(command, { stdio: 'inherit' }))
+}
+// Create the reports folder and move the reports from cypress and jest inside it
+fs.emptyDirSync(REPORTS_FOLDER)
+fs.copyFileSync(`${COVERAGE_CYPRESS_FOLDER}/coverage-final.json`, `${REPORTS_FOLDER}/from-cypress.json`)
+fs.copyFileSync(`${COVERAGE_JEST_FOLDER}/coverage-final.json`, `${REPORTS_FOLDER}/from-jest.json`)
+fs.emptyDirSync('.nyc_output')
+fs.emptyDirSync(FINAL_OUTPUT_FOLDER)
+// Run "nyc merge" inside the reports folder, merging the two coverage files into one,
+// then generate the final report on the coverage folder
+run([
+  // "nyc merge" will create a "coverage.json" file on the root, we move it to .nyc_output
+  `nyc merge ${REPORTS_FOLDER} && mv coverage.json .nyc_output/out.json`,
+  `nyc report --reporter lcov --report-dir ${FINAL_OUTPUT_FOLDER}`
+])

--- a/template/scripts/coverage-merge.js
+++ b/template/scripts/coverage-merge.js
@@ -6,12 +6,14 @@ const { execSync } = require('child_process')
 const fs = require('fs-extra')
 const COVERAGE_JEST_FOLDER = 'coverage'
 const COVERAGE_CYPRESS_FOLDER = 'coverage/cypress'
+const NYC_FOLDER = '.nyc_output'
 const REPORTS_FOLDER = 'coverage/reports'
 const FINAL_OUTPUT_FOLDER = 'coverage/merged'
 const run = (commands) => {
   commands.forEach((command) => execSync(command, { stdio: 'inherit' }))
 }
 // Create the reports folder and move the reports from cypress and jest inside it
+fs.emptyDirSync(NYC_FOLDER)
 fs.emptyDirSync(REPORTS_FOLDER)
 fs.copyFileSync(`${COVERAGE_CYPRESS_FOLDER}/coverage-final.json`, `${REPORTS_FOLDER}/from-cypress.json`)
 fs.copyFileSync(`${COVERAGE_JEST_FOLDER}/coverage-final.json`, `${REPORTS_FOLDER}/from-jest.json`)


### PR DESCRIPTION
## What happened 

- Add code coverage command in `package.json` 
- Add a coverage merge script to associate Jest Tests code coverage with the Cypress Code Coverage info
- Add a rule in the README.md file

Extra
- Add `.gitignore` rules for cypress screenshots and videos

## Insight

`N/A`

## Proof Of Work 💪

The `test:coverage` command works out of the box on a fresh "just created" application.

![image](https://user-images.githubusercontent.com/77609814/142800156-882ec14e-3d1c-48ec-9ea7-7002e1be2f42.png)

### Confirming coverage merge with a new `BaseButton` component

**Context:**

| 1x Switch case for button classes | Another switch case for button text |
|---|---|
|![image](https://user-images.githubusercontent.com/77609814/142801359-4e44ab2f-2928-4c24-b0b2-8307fdf493f1.png)|![image](https://user-images.githubusercontent.com/77609814/142801381-6352d5c2-80ec-4e1e-b17f-bd831fcb9e28.png)|

The jest tests will only cover the first case of each switch.
The cypress tests will only cover the second case of each switch. 

Given one or many of these tests, we expect the code coverage to reflect the right "uncovered lines of code".
_(line numbers is the last column of the below screenshots)_

> Note I've mocked the BaseButton component in the <App> Jest Test, to ensure this component will not be rendered inside the <App> tests. The BaseButton component is only rendered in its dedicated tests.

**Given only the jest test:**

![image](https://user-images.githubusercontent.com/77609814/142801304-86fef8d5-dcfd-4364-bf8b-e857665274f9.png)

**Given both cypress and jest tests:**

![image](https://user-images.githubusercontent.com/77609814/142801832-b0920e46-2237-4147-8fb2-49e3726a8f12.png)

**Given none of these tests:**

> ℹ️ testing this part AFTER the others is important to confirm that previous reports do not impact the newly generated report — this ensures regression to be visible!

![image](https://user-images.githubusercontent.com/77609814/142802898-b7fe3242-6610-4465-8925-7462e3419eef.png)

**Given only the cypress tests**

![image](https://user-images.githubusercontent.com/77609814/142803183-9b8f0944-76f9-4cd2-86ad-0dbb7a5db391.png)
