### PR TITLE
[#31] Fix: Cypress testing library command not found

### DIFF
--- a/template.json
+++ b/template.json
@@ -8,7 +8,7 @@
       "@testing-library/react": "11.1.0",
       "@testing-library/user-event": "12.1.10",
       "@types/jest": "26.0.15",
-      "@types/node": "12.0.0",
+      "@types/node": "14.0.0",
       "@types/react": "17.0.0",
       "@types/react-dom": "17.0.0",
       "@typescript-eslint/eslint-plugin": "4.22.1",

--- a/template/cypress/integration/init.spec.ts
+++ b/template/cypress/integration/init.spec.ts
@@ -5,5 +5,6 @@ describe('Cypress', () => {
 
   it('visits the app', () => {
     cy.visit('/')
+    cy.findByTestId('app-link').should('be.visible')
   })
 })

--- a/template/cypress/support/commands.ts
+++ b/template/cypress/support/commands.ts
@@ -1,1 +1,3 @@
+import '@testing-library/cypress/add-commands';
+
 // Import commands from the commands folder.


### PR DESCRIPTION
Resolves #31 

## What happened 

We usually use `cy.findByTestId(...)` on the UI test which is from `@testing-library/cypress` so we need to import the 
  `@testing-library/cypress/add-commands` as it's not the original command from Cypress

## Insight

As the [latest released CRA](https://github.com/facebook/create-react-app/releases/tag/v5.0.0) drop the support of Node 12 so I updated the `@types/node` to 14 instead

## Proof Of Work 💪

Check out this branch and bootstrap a project by running

`yarn create react-app my-app --template file:./`

after the app is successfully generated, goes to the application path and run it 

`yarn start`

then run the Cypress test on another terminal, the test should pass

![Screen Shot 2565-03-15 at 14 59 21](https://user-images.githubusercontent.com/1772999/158332526-9466a005-c462-41d8-8491-eb818a449da1.png)

