### PR TITLE
[#30] Add testIdAttribute configuration for @testing-library/react

### DIFF
--- a/template/src/App.test.tsx
+++ b/template/src/App.test.tsx
@@ -7,7 +7,8 @@ import App from './App'
 test('renders learn react link', () => {
   render(<App />)
 
-  const linkElement = screen.getByText('sample_page.learn_react')
+  const linkElement = screen.getByTestId('app-link')
 
   expect(linkElement).toBeInTheDocument()
+  expect(linkElement).toHaveTextContent('sample_page.learn_react')
 })

--- a/template/src/App.test.tsx
+++ b/template/src/App.test.tsx
@@ -4,11 +4,13 @@ import { render, screen } from '@testing-library/react'
 
 import App from './App'
 
-test('renders learn react link', () => {
-  render(<App />)
+describe('App', () => {
+  it('renders learn react link', () => {
+    render(<App />)
 
-  const linkElement = screen.getByTestId('app-link')
+    const linkElement = screen.getByTestId('app-link')
 
-  expect(linkElement).toBeInTheDocument()
-  expect(linkElement).toHaveTextContent('sample_page.learn_react')
+    expect(linkElement).toBeInTheDocument()
+    expect(linkElement).toHaveTextContent('sample_page.learn_react')
+  })
 })

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -13,7 +13,13 @@ function App(): JSX.Element {
       <header className="app-header">
         <img src={logo} className="app-logo" alt="logo" />
         <p>{t('sample_page.message', { codeSample: '<code>src/App.tsx</code>' })}</p>
-        <a className="app-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer">
+        <a
+          className="app-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-test-id="app-link"
+        >
           {t('sample_page.learn_react')}
         </a>
       </header>

--- a/template/src/lib/requestManager.test.ts
+++ b/template/src/lib/requestManager.test.ts
@@ -1,0 +1,49 @@
+/* eslint camelcase: ["error", {allow: ["snake_case_key"]}] */
+import axios, { AxiosResponse } from 'axios';
+
+import { mockAxiosError } from 'tests/error';
+
+import requestManager, { defaultOptions } from './requestManager';
+
+jest.mock('axios');
+
+describe('requestManager', () => {
+  const endPoint = 'https://sample-endpoint.com/api/';
+
+  it('fetches successfully data from an API', async () => {
+    const responseData = {
+      data: [
+        { id: 1, value: 'first object' },
+        { id: 2, value: 'second object' },
+      ],
+    };
+
+    const requestSpy = jest.spyOn(axios, 'request').mockImplementation(() => Promise.resolve(responseData));
+
+    await expect(requestManager('POST', endPoint)).resolves.toEqual(responseData.data);
+
+    requestSpy.mockRestore();
+  });
+
+  it('fetches the provided endPoint', async () => {
+    const requestOptions = { ...defaultOptions, method: 'POST', url: endPoint };
+
+    const requestSpy = jest.spyOn(axios, 'request').mockImplementation(() => Promise.resolve({}));
+
+    await requestManager('POST', endPoint);
+
+    expect(axios.request).toHaveBeenCalledWith(requestOptions);
+
+    requestSpy.mockRestore();
+  });
+
+  it('fetches erroneously data from an API', async () => {
+    const errorMessage = 'Network Error';
+
+    const requestSpy = jest.spyOn(axios, 'request').mockImplementation(() => Promise.reject(new Error(errorMessage)));
+
+    await expect(requestManager('POST', endPoint)).rejects.toThrow(errorMessage);
+
+    requestSpy.mockRestore();
+  });
+});

--- a/template/src/lib/requestManager.ts
+++ b/template/src/lib/requestManager.ts
@@ -1,6 +1,6 @@
 import axios, { Method as HTTPMethod, ResponseType, AxiosRequestConfig, AxiosResponse } from 'axios'
 
-const defaultOptions: { responseType: ResponseType } = {
+export const defaultOptions: { responseType: ResponseType } = {
   responseType: 'json'
 }
 
@@ -14,7 +14,7 @@ const defaultOptions: { responseType: ResponseType } = {
  *                   an error object for its reason
  */
 
-function requestManager(method: HTTPMethod, endpoint: string, requestOptions: AxiosRequestConfig = {}) {
+const requestManager = (method: HTTPMethod, endpoint: string, requestOptions: AxiosRequestConfig = {}) => {
   const requestParams: AxiosRequestConfig = {
     method,
     url: endpoint,

--- a/template/src/setupTests.ts
+++ b/template/src/setupTests.ts
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+import { configure } from '@testing-library/dom';
+
+configure({
+  testIdAttribute: 'data-test-id',
+});


### PR DESCRIPTION
Resolve #30 

## What happened 

- Configured the test id attribute for the unit test so we can use the same attribute configured on the UI test which is `data-test-id`
- Update the existing unit test to use the `.findByTest(...)`
- Add the missing test case for the request manager

## Insight

N/A

## Proof Of Work 💪

Check out this branch and bootstrap a project by running

`yarn create react-app my-app --template file:./`

after the app is successfully generated, goes to the application path and run the test

`yarn test`

all the tests should pass

![Screen Shot 2565-03-15 at 16 53 36](https://user-images.githubusercontent.com/1772999/158352437-be38d2d2-4ba1-46f0-84b2-81168b166eb0.png)

