### PR TITLE
[#44] Fix: cannot find module 'tests/error' linting error

### DIFF
--- a/template/src/lib/requestManager.test.ts
+++ b/template/src/lib/requestManager.test.ts
@@ -1,7 +1,5 @@
 /* eslint camelcase: ["error", {allow: ["snake_case_key"]}] */
-import axios, { AxiosResponse } from 'axios';
-
-import { mockAxiosError } from 'tests/error';
+import axios from 'axios';
 
 import requestManager, { defaultOptions } from './requestManager';
 


### PR DESCRIPTION
close https://github.com/nimblehq/react-templates/issues/44

## What happened 👀

Remove unused import

## Insight 📝

`N/A`

## Proof Of Work 📹

Template is working: 
<img width="180" alt="image" src="https://user-images.githubusercontent.com/77609814/158926797-3eab09fe-29aa-4692-baff-a5d9b0e162a7.png">
cf

The project runs without linting error (I have commented the `max-len` linting rule related to #43):
<img width="875" alt="image" src="https://user-images.githubusercontent.com/77609814/158927009-6afc2446-75c4-4d70-9139-63a10b03a832.png">

