### PR TITLE
[#43] Update Prettier and ESLint rules to make it consistent with our convention

### DIFF
--- a/template.json
+++ b/template.json
@@ -18,6 +18,7 @@
       "cypress-react-selector": "2.3.16",
       "eslint": "8.11.0",
       "eslint-config-prettier": "8.5.0",
+      "eslint-import-resolver-typescript": "2.5.0",
       "eslint-plugin-cypress": "2.12.1",
       "eslint-plugin-import": "2.25.4",
       "eslint-plugin-jest": "26.1.1",

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     es6: true,
     browser: true,
     node: true,
-    jest: true
+    jest: true,
   },
   extends: [
     '@nimblehq/eslint-config-nimble',
@@ -12,33 +12,30 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:import/errors',
-    'plugin:prettier/recommended'
+    'plugin:prettier/recommended',
   ],
   overrides: [
     {
       files: 'src/tests/**/*.test.ts',
-      extends: [
-        'plugin:jest/recommended',
-        'plugin:jest/style'
-      ]
+      extends: ['plugin:jest/recommended', 'plugin:jest/style'],
     },
     {
       files: 'cypress/**/*.ts',
-      extends: [
-        'plugin:cypress/recommended'
-      ]
-    }
+      extends: ['plugin:cypress/recommended'],
+    },
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {
-      jsx: true
-    }
+      jsx: true,
+    },
   },
   rules: {
-    'max-len': ['error', { code: 120 }],
+    semi: 'error',
+    'comma-dangle': ['error', 'always-multiline'],
+    'max-len': ['error', { code: 130 }],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-filename-extension': [2, { extensions: ['.tsx'] }],
@@ -50,21 +47,21 @@ module.exports = {
           {
             pattern: 'react*',
             group: 'external',
-            position: 'before'
+            position: 'before',
           },
           {
             pattern: 'css/*|*.scss|*.svg|.png',
             group: 'internal',
-            position: 'after'
-          }
+            position: 'after',
+          },
         ],
         pathGroupsExcludedImportTypes: ['react'],
         'newlines-between': 'always',
         alphabetize: {
           order: 'asc',
-          caseInsensitive: true
-        }
-      }
+          caseInsensitive: true,
+        },
+      },
     ],
     'import/extensions': [
       'error',
@@ -74,8 +71,8 @@ module.exports = {
         svg: 'always',
         png: 'always',
         json: 'always',
-        spec: 'always'
-      }
+        spec: 'always',
+      },
     ],
     'no-use-before-define': 'off',
     'no-unused-vars': 'off',
@@ -83,15 +80,18 @@ module.exports = {
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': ['error'],
+    'prettier/prettier': ['error', { semi: true, trailingComma: 'es5' }],
   },
   settings: {
     react: {
-      version: 'detect'
+      version: 'detect',
     },
     'import/resolver': {
+      typescript: {},
       node: {
-        extensions: ['.ts', '.tsx']
-      }
-    }
-  }
-}
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        moduleDirectory: ['node_modules', 'src/'],
+      },
+    },
+  },
+};

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -33,9 +33,6 @@ module.exports = {
     },
   },
   rules: {
-    semi: 'error',
-    'comma-dangle': ['error', 'always-multiline'],
-    'max-len': ['error', { code: 130 }],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-filename-extension': [2, { extensions: ['.tsx'] }],

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -77,7 +77,7 @@ module.exports = {
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': ['error'],
-    'prettier/prettier': ['error', { semi: true, trailingComma: 'es5' }],
+    'prettier/prettier': ['error'],
   },
   settings: {
     react: {
@@ -91,4 +91,4 @@ module.exports = {
       },
     },
   },
-};
+}

--- a/template/.prettierrc
+++ b/template/.prettierrc
@@ -1,6 +1,7 @@
 {
-	"semi": false,
+	"semi": true,
 	"singleQuote": true,
-	"trailingComma": "none",
-	"printWidth": 120
+	"trailingComma": "es5",
+	"printWidth": 130,
+	"tabWidth": 2
 }

--- a/template/cypress/integration/init.spec.ts
+++ b/template/cypress/integration/init.spec.ts
@@ -1,10 +1,10 @@
 describe('Cypress', () => {
   it('is working', () => {
-    expect(true).to.equal(true)
-  })
+    expect(true).to.equal(true);
+  });
 
   it('visits the app', () => {
-    cy.visit('/')
-    cy.findByTestId('app-link').should('be.visible')
-  })
-})
+    cy.visit('/');
+    cy.findByTestId('app-link').should('be.visible');
+  });
+});

--- a/template/cypress/plugins/index.ts
+++ b/template/cypress/plugins/index.ts
@@ -1,15 +1,15 @@
-import browserify from '@cypress/browserify-preprocessor'
-import task from '@cypress/code-coverage/task'
+import browserify from '@cypress/browserify-preprocessor';
+import task from '@cypress/code-coverage/task';
 
 module.exports = (on, config) => {
-  task(on, config)
+  task(on, config);
 
   on(
     'file:preprocessor',
     browserify({
-      typescript: require.resolve('typescript')
+      typescript: require.resolve('typescript'),
     })
-  )
+  );
 
-  return config
-}
+  return config;
+};

--- a/template/cypress/support/component-selector.ts
+++ b/template/cypress/support/component-selector.ts
@@ -1,1 +1,1 @@
-import 'cypress-react-selector'
+import 'cypress-react-selector';

--- a/template/cypress/support/configure-testing-library.ts
+++ b/template/cypress/support/configure-testing-library.ts
@@ -1,4 +1,4 @@
 // we are configuring the default lookout of data attribute of
 // cypress-testing-library(https://github.com/testing-library/cypress-testing-library).
-import { configure } from '@testing-library/cypress'
-configure({ testIdAttribute: 'data-test-id' })
+import { configure } from '@testing-library/cypress';
+configure({ testIdAttribute: 'data-test-id' });

--- a/template/gitignore
+++ b/template/gitignore
@@ -24,3 +24,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# editors
+.vscode

--- a/template/src/App.test.tsx
+++ b/template/src/App.test.tsx
@@ -1,16 +1,16 @@
-import React from 'react'
+import React from 'react';
 
-import { render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react';
 
-import App from './App'
+import App from './App';
 
 describe('App', () => {
   it('renders learn react link', () => {
-    render(<App />)
+    render(<App />);
 
-    const linkElement = screen.getByTestId('app-link')
+    const linkElement = screen.getByTestId('app-link');
 
-    expect(linkElement).toBeInTheDocument()
-    expect(linkElement).toHaveTextContent('sample_page.learn_react')
-  })
-})
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveTextContent('sample_page.learn_react');
+  });
+});

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -19,6 +19,6 @@ const App = (): JSX.Element => {
       </header>
     </div>
   );
-}
+};
 
 export default App;

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -5,7 +5,7 @@ import logo from './assets/images/logo.svg';
 import './dummy.scss';
 import './assets/stylesheets/application.scss';
 
-function App(): JSX.Element {
+const App = (): JSX.Element => {
   const { t } = useTranslation();
 
   return (

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -13,13 +13,7 @@ function App(): JSX.Element {
       <header className="app-header">
         <img src={logo} className="app-logo" alt="logo" />
         <p>{t('sample_page.message', { codeSample: '<code>src/App.tsx</code>' })}</p>
-        <a
-          className="app-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-test-id="app-link"
-        >
+        <a className="app-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer" data-test-id="app-link">
           {t('sample_page.learn_react')}
         </a>
       </header>

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
-import logo from './assets/images/logo.svg'
-import './dummy.scss'
-import './assets/stylesheets/application.scss'
+import logo from './assets/images/logo.svg';
+import './dummy.scss';
+import './assets/stylesheets/application.scss';
 
 function App(): JSX.Element {
-  const { t } = useTranslation()
+  const { t } = useTranslation();
 
   return (
     <div className="app">
@@ -24,7 +24,7 @@ function App(): JSX.Element {
         </a>
       </header>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/template/src/__mocks__/i18n.ts
+++ b/template/src/__mocks__/i18n.ts
@@ -1,3 +1,3 @@
-const configureI18n = jest.fn()
+const configureI18n = jest.fn();
 
-export default configureI18n
+export default configureI18n;

--- a/template/src/__mocks__/react-i18next.ts
+++ b/template/src/__mocks__/react-i18next.ts
@@ -1,8 +1,8 @@
 const useMock = {
   t: (k: string): string => {
-    return k
+    return k;
   },
-  i18n: {}
-}
+  i18n: {},
+};
 
-export const useTranslation = (): { t: (k: string) => string; i18n: Record<string, never> } => useMock
+export const useTranslation = (): { t: (k: string) => string; i18n: Record<string, never> } => useMock;

--- a/template/src/i18n.ts
+++ b/template/src/i18n.ts
@@ -1,12 +1,12 @@
-import { initReactI18next } from 'react-i18next'
+import { initReactI18next } from 'react-i18next';
 
-import i18n from 'i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
-import Backend from 'i18next-http-backend'
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
 
-export const supportedLanguages = ['en']
+export const supportedLanguages = ['en'];
 
-const DEFAULT_FALLBACK_LANGUAGE = 'en'
+const DEFAULT_FALLBACK_LANGUAGE = 'en';
 
 const configureI18n = (): void => {
   i18n
@@ -27,9 +27,9 @@ const configureI18n = (): void => {
       supportedLngs: supportedLanguages,
 
       interpolation: {
-        escapeValue: false // not needed for react as it escapes by default
-      }
-    })
-}
+        escapeValue: false, // not needed for react as it escapes by default
+      },
+    });
+};
 
-export default configureI18n
+export default configureI18n;

--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -1,11 +1,11 @@
-import React, { Suspense } from 'react'
-import ReactDOM from 'react-dom'
+import React, { Suspense } from 'react';
+import ReactDOM from 'react-dom';
 
-import App from './App'
-import configureI18n from './i18n'
-import reportWebVitals from './reportWebVitals'
+import App from './App';
+import configureI18n from './i18n';
+import reportWebVitals from './reportWebVitals';
 
-configureI18n()
+configureI18n();
 
 ReactDOM.render(
   <React.StrictMode>
@@ -14,9 +14,9 @@ ReactDOM.render(
     </Suspense>
   </React.StrictMode>,
   document.getElementById('root')
-)
+);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals()
+reportWebVitals();

--- a/template/src/lib/requestManager.test.ts
+++ b/template/src/lib/requestManager.test.ts
@@ -1,4 +1,3 @@
-/* eslint camelcase: ["error", {allow: ["snake_case_key"]}] */
 import axios from 'axios';
 
 import requestManager, { defaultOptions } from './requestManager';

--- a/template/src/lib/requestManager.ts
+++ b/template/src/lib/requestManager.ts
@@ -1,8 +1,8 @@
-import axios, { Method as HTTPMethod, ResponseType, AxiosRequestConfig, AxiosResponse } from 'axios'
+import axios, { Method as HTTPMethod, ResponseType, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export const defaultOptions: { responseType: ResponseType } = {
-  responseType: 'json'
-}
+  responseType: 'json',
+};
 
 /**
  * The main API access function that comes preconfigured with useful defaults.
@@ -14,17 +14,21 @@ export const defaultOptions: { responseType: ResponseType } = {
  *                   an error object for its reason
  */
 
-const requestManager = (method: HTTPMethod, endpoint: string, requestOptions: AxiosRequestConfig = {}) => {
+const requestManager = (
+  method: HTTPMethod,
+  endpoint: string,
+  requestOptions: AxiosRequestConfig = {}
+): Promise<AxiosResponse> => {
   const requestParams: AxiosRequestConfig = {
     method,
     url: endpoint,
     ...defaultOptions,
-    ...requestOptions
-  }
+    ...requestOptions,
+  };
 
-  return axios.request(requestParams).then((response: AxiosResponse<any>) => {
-    return response.data
-  })
-}
+  return axios.request(requestParams).then((response: AxiosResponse) => {
+    return response.data;
+  });
+};
 
-export default requestManager
+export default requestManager;

--- a/template/src/reportWebVitals.ts
+++ b/template/src/reportWebVitals.ts
@@ -3,13 +3,13 @@ import type { ReportHandler } from 'web-vitals'
 const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry)
-      getFID(onPerfEntry)
-      getFCP(onPerfEntry)
-      getLCP(onPerfEntry)
-      getTTFB(onPerfEntry)
-    })
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
   }
-}
+};
 
-export default reportWebVitals
+export default reportWebVitals;

--- a/template/src/reportWebVitals.ts
+++ b/template/src/reportWebVitals.ts
@@ -1,4 +1,4 @@
-import type { ReportHandler } from 'web-vitals'
+import type { ReportHandler } from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/template/src/setupTests.ts
+++ b/template/src/setupTests.ts
@@ -2,7 +2,7 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import { configure } from '@testing-library/dom';
 
 configure({

--- a/template/src/types/react-i18next.d.ts
+++ b/template/src/types/react-i18next.d.ts
@@ -1,7 +1,7 @@
 import 'react-i18next';
 import { TFuncKey } from 'react-i18next';
 
-import defaultRes from '../../public/locales/en/translation.json'
+import defaultRes from '../../public/locales/en/translation.json';
 
 export type TranslationKey = TFuncKey<'translation', undefined, { translation: typeof defaultRes }>;
 


### PR DESCRIPTION
Resolve https://github.com/nimblehq/react-templates/issues/43

## What happened 👀

- Update the Prettier configuration to cover the code formatting rules
- Update the ESLint rule to leave the code format rules to Prettier
- Fix the code format to align with our [Javascript](https://nimblehq.co/compass/development/code-conventions/javascript/) and [React](https://nimblehq.co/compass/development/code-conventions/javascript/react/) conventions

## Insight 📝

N/A

## Proof Of Work 📹

Tested manually by checkout this branch and bootstrap a fresh new app

`yarn create react-app my-app --template file:./`

goes to the app path and start the app, it works fine

![Screen Shot 2565-03-21 at 18 40 29](https://user-images.githubusercontent.com/1772999/159254177-1ca63dce-7ae2-41ab-8b27-8e5ba6e778bd.png)

run the lint check and it should pass too
![Screen Shot 2565-03-21 at 18 39 46](https://user-images.githubusercontent.com/1772999/159254267-b85319de-1f83-4a64-b129-510a81d779a5.png)


