### PR TITLE
[#28] Add the Github Actions test workflow template for React projects

### DIFF
--- a/template.json
+++ b/template.json
@@ -49,6 +49,7 @@
       "stylelint:fix": "stylelint '**/*.scss' --fix",
       "codebase:lint": "yarn lint && yarn stylelint",
       "codebase:fix": "yarn lint:fix && yarn stylelint:fix",
+      "cypress": "start-server-and-test start 3000 cypress:run",
       "cypress:run": "cypress run",
       "cypress:open": "cypress open"
     },
@@ -62,7 +63,8 @@
       "excludeAfterRemap": true
     },
     "devDependencies": {
-      "@cypress/instrument-cra": "1.4.0"
+      "@cypress/instrument-cra": "1.4.0",
+      "start-server-and-test": "1.14.0"
     }
   }
 }

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on: push
+
+jobs:
+  test:
+    name: Run linters and tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup node and restore cached dependencies
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run integration tests
+        run: npm run cypress


### PR DESCRIPTION
Close https://github.com/nimblehq/react-templates/issues/28

## What happened 👀

- Add the Github Actions test workflow template for React projects
- Add [start-server-and-test](https://www.npmjs.com/package/start-server-and-test) to run cypress on CI easily

## Insight 📝

- I put all linters, unit tests, integration tests into a job as they are quite simple at the beginning. But if you think we should have separated jobs for them, just let me know
- Use `start-server-and-test` package to start and test the integration, I created a new `cypress` script to call it.

## Proof Of Work 📹

Create a new project from the template and it worked well:
https://github.com/hoangmirs/test-react-workflow/actions/runs/2069986416
