### PR TITLE
[#53] Add react-router to the template

### DIFF
--- a/template.json
+++ b/template.json
@@ -31,6 +31,7 @@
       "i18next-http-backend": "1.4.0",
       "prettier": "2.6.0",
       "react-i18next": "11.16.1",
+      "react-router-dom": "6.3.0",
       "sass": "1.49.11",
       "stylelint": "14.6.0",
       "stylelint-config-property-sort-order-smacss": "9.0.0",

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useRoutes } from 'react-router-dom';
 
-import './dummy.scss';
-import './assets/stylesheets/application.scss';
+import 'dummy.scss';
+import 'assets/stylesheets/application.scss';
 
-import routes from './routes';
+import routes from 'routes';
 
 const App = (): JSX.Element => {
   const appRoutes = useRoutes(routes);

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,24 +1,15 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { useRoutes } from 'react-router-dom';
 
-import logo from './assets/images/logo.svg';
 import './dummy.scss';
 import './assets/stylesheets/application.scss';
 
-const App = (): JSX.Element => {
-  const { t } = useTranslation();
+import routes from './routes';
 
-  return (
-    <div className="app">
-      <header className="app-header">
-        <img src={logo} className="app-logo" alt="logo" />
-        <p>{t('sample_page.message', { codeSample: '<code>src/App.tsx</code>' })}</p>
-        <a className="app-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer" data-test-id="app-link">
-          {t('sample_page.learn_react')}
-        </a>
-      </header>
-    </div>
-  );
+const App = (): JSX.Element => {
+  const appRoutes = useRoutes(routes);
+
+  return <>{appRoutes}</>;
 };
 
 export default App;

--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import configureI18n from './i18n';
@@ -10,7 +11,9 @@ configureI18n();
 ReactDOM.render(
   <React.StrictMode>
     <Suspense fallback="loading">
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Suspense>
   </React.StrictMode>,
   document.getElementById('root')

--- a/template/src/routes/index.tsx
+++ b/template/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RouteObject } from 'react-router-dom';
 
-import HomeScreen from '../screens/Home';
+import HomeScreen from 'screens/Home';
 
 const routes: RouteObject[] = [
   {

--- a/template/src/routes/index.tsx
+++ b/template/src/routes/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+
+import HomeScreen from '../screens/Home';
+
+const routes: RouteObject[] = [
+  {
+    path: '/',
+    element: <HomeScreen />,
+  },
+];
+
+export default routes;

--- a/template/src/screens/Home.test.tsx
+++ b/template/src/screens/Home.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-import App from './App';
+import HomeScreen from './Home';
 
-describe('App', () => {
+describe('HomeScreen', () => {
   it('renders learn react link', () => {
-    render(<App />);
+    render(<HomeScreen />);
 
     const linkElement = screen.getByTestId('app-link');
 

--- a/template/src/screens/Home.tsx
+++ b/template/src/screens/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import logo from '../assets/images/logo.svg';
+import logo from 'assets/images/logo.svg';
 
 const HomeScreen = (): JSX.Element => {
   const { t } = useTranslation();

--- a/template/src/screens/Home.tsx
+++ b/template/src/screens/Home.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import logo from '../assets/images/logo.svg';
+
+const HomeScreen = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <img src={logo} className="app-logo" alt="logo" />
+        <p>{t('sample_page.message', { codeSample: '<code>src/App.tsx</code>' })}</p>
+        <a className="app-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer" data-test-id="app-link">
+          {t('sample_page.learn_react')}
+        </a>
+      </header>
+    </div>
+  );
+};
+
+export default HomeScreen;

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+  }
+}


### PR DESCRIPTION
Close https://github.com/nimblehq/react-templates/issues/53

## What happened 👀

- Add [react-router](https://reactrouter.com/)
- Add a compilerOptions `baseUrl` to typescript configuration. Other configurations will be added automatically:
![mirs_Mirss-MacBook-Pro___Documents_Nimble_Projects_internal](https://user-images.githubusercontent.com/7344405/161678307-476311eb-ee18-4f24-bc7d-d3c8e5363664.png)


## Insight 📝

- Both [route object](https://reactrouter.com/docs/en/v6/examples/route-objects) and route component use `useRoutes` hook, then they should be the same.
- Using route objects seems more compact, so I recommend using it. You guys can give your thoughts as well.

## Proof Of Work 📹

Created a new project from this template and it worked properly
