### PR TITLE
[#69] Add a GitHub Action for displaying Jest test coverage information in pull requests

### DIFF
--- a/template.json
+++ b/template.json
@@ -44,6 +44,7 @@
     "scripts": {
       "start": "react-scripts -r @cypress/instrument-cra start",
       "test:coverage": "react-scripts test --coverage --watchAll=false && npm run cypress:run && node ./scripts/coverage-merge.js && nyc report",
+      "test:merge-coverage": "node ./scripts/coverage-merge.js",
       "lint": "eslint ./src ./cypress --ext .ts,.tsx",
       "lint:fix": "eslint ./src ./cypress --ext .ts,.tsx --fix",
       "stylelint": "stylelint '**/*.scss'",
@@ -65,6 +66,10 @@
     },
     "devDependencies": {
       "@cypress/instrument-cra": "1.4.0",
+      "danger": "10.9.0",
+      "danger-plugin-code-coverage": "1.1.9",
+      "danger-plugin-istanbul-coverage": "1.6.2",
+      "danger-plugin-jest-codecov": "0.0.8",
       "start-server-and-test": "1.14.0"
     }
   }

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: push
+on: pull_request
 
 jobs:
   test:
@@ -28,33 +28,15 @@ jobs:
         run: npm run lint
 
       - name: Run unit tests
-        run: npm run test
+        run: npm test -- --coverage
 
-  cypress-run:
-    name: Run Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Run integration tests
+        run: npm run cypress
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          build: npm run build
-          start: npm start
+      - name: Merge code coverage reports
+        run: npm run test:merge-coverage
 
-  coverage:
-    name: Merge coverage data
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Jest Coverage report
-        uses: artiomtr/jest-coverage-report-action@v2.0.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-manager: npm
-          test-script: npm run test
-          threshold: 80 # prevent PR merge under 80% coverage
+      - name: Danger
+        run: npx danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -30,5 +30,31 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
-      - name: Run integration tests
-        run: npm run cypress
+  cypress-run:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          build: npm run build
+          start: npm start
+
+  coverage:
+    name: Merge coverage data
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Jest Coverage report
+        uses: artiomtr/jest-coverage-report-action@v2.0.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-manager: npm
+          test-script: npm run test
+          threshold: 80 # prevent PR merge under 80% coverage

--- a/template/dangerfile.ts
+++ b/template/dangerfile.ts
@@ -1,0 +1,39 @@
+import { schedule } from 'danger';
+import { istanbulCoverage } from 'danger-plugin-istanbul-coverage';
+
+schedule(
+  istanbulCoverage({
+    // Set a custom success message
+    customSuccessMessage: 'Congrats, coverage is good',
+
+    // Set a custom failure message
+    customFailureMessage: 'Coverage is a little low, take a look',
+
+    // How to sort the entries in the table
+    entrySortMethod: 'least-coverage', // || 'alphabetically' || 'most-coverage' || 'largest-file-size' ||'smallest-file-size' || 'uncovered-lines'
+
+    // Add a maximum number of entries to display
+    numberOfEntries: 15,
+
+    // The location of the istanbul coverage file.
+    // coveragePath: './.nyc_output/out.json', // The merged JSON coverage data
+    // Alternatively, if you have multiple coverage summaries, you can merge them into one report
+    // coveragePaths: ["./coverage/reports/from-cypress.json", "./coverage/reports/from-jest.json"],
+    // You can also specify the format, instead of letting it be inferred from the file name
+    coveragePath: { path: './coverage/merged/lcov.info', type: 'lcov' /* ||  "json-summary" */ },
+
+    // Which set of files to summarise from the coverage file.
+    reportFileSet: 'all', // || "modified" || "created" || "createdOrModified"
+
+    // What to do when the PR doesn't meet the minimum code coverage threshold
+    reportMode: 'message', // || "warn" || "fail"
+
+    // Minimum coverage threshold percentages. Compared against the cumulative coverage of the reportFileSet.
+    threshold: {
+      statements: 80,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+    },
+  })
+);


### PR DESCRIPTION
https://github.com/nimblehq/react-templates/issues/69

## What happened 👀

- [x] Test different danger plugins
- [x] Vote for the final one to be used
- [x] Implement the code coverage in the Test GitHub Action

## Insight 📝

| ✅  Solution A | 🚫 Solution B | 🚫 Solution C |
|---|---|---|
|'[danger-plugin-istanbul-coverage](https://github.com/darcy-rayner/danger-plugin-istanbul-coverage)'|'[danger-plugin-code-coverage](https://github.com/Spoutnik97/danger-plugin-code-coverage)'|'[danger-plugin-jest-codecov](https://github.com/EdgePetrol/danger-plugin-jest-codecov)'|
|![image](https://user-images.githubusercontent.com/77609814/162162504-f28fecb8-e279-4608-95c7-cdab6e5af485.png)|![image](https://user-images.githubusercontent.com/77609814/162163678-a338b008-56ae-441f-a195-acd3e16dde20.png)|![image](https://user-images.githubusercontent.com/77609814/162165870-fbc3ed1a-d6d6-49f7-86a1-662c983452bd.png)|
| Very configurable (number of files, ordering rule, threasholds percent and messages, ...) | More colorful but not configurable | Enable to compare code coverage change versus the origin branch, much more complex to implement |

> Note that solution C ('danger-plugin-jest-codecov') requires more effort to be implemented as it aims to compare both target and source branches' code coverage (I would need to check out the code from the target branch and run the test coverage there too).

## Poll — Let's vote!

[![](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/A%20%E2%80%94%20danger-plugin-istanbul-coverage)](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/A%20%E2%80%94%20danger-plugin-istanbul-coverage/vote)
[![](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/B%20%E2%80%94%20danger-plugin-code-coverage)](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/B%20%E2%80%94%20danger-plugin-code-coverage/vote)
[![](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/C%20%E2%80%94%20danger-plugin-jest-codecov)](https://api.gh-polls.com/poll/01G0GF09XAZ3TMZSQZ0QBHYTW2/C%20%E2%80%94%20danger-plugin-jest-codecov/vote)

> 💡 Please suggest alternative plugins if you know some!


## Proof Of Work 📹

Final tests have been done in this repository: https://github.com/malparty/coveragewedn/pull/1

- Adding a new commit in an existing PR will "replace" the danger message (no spam accumulation)
- Default configuration: 80% thresholds, 15 files displayed, ordered by least covered.

<img width="918" alt="image" src="https://user-images.githubusercontent.com/77609814/164197897-5fa9580e-9a4f-42d4-8aca-923213fc07e9.png">


Action running successfuly: 

<img width="406" alt="image" src="https://user-images.githubusercontent.com/77609814/164198381-975540a3-93b3-49fb-8d80-8fa7554386ae.png">
