### PR TITLE
[#66] Support only one package manager or keep both? (use only npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ To use this template, add `--template nimble` when creating a new app from the `
 
 ```sh
 npx create-react-app my-app --template nimble
-
-# or
-
-yarn create react-app my-app --template nimble
 ```
 
 For more information about `create-react-app`, please refer to:
@@ -67,10 +63,6 @@ To test the template locally, simply run the template install command with the p
 
 ```sh
 npx create-react-app my-app --template file:{../path/to/your/local/template/repo}
-
-# or
-
-yarn create react-app my-app --template file:{../path/to/your/local/template/repo}
 ```
 
 ## License

--- a/template.json
+++ b/template.json
@@ -43,13 +43,13 @@
     },
     "scripts": {
       "start": "react-scripts -r @cypress/instrument-cra start",
-      "test:coverage": "react-scripts test --coverage --watchAll=false && yarn cypress:run && node ./scripts/coverage-merge.js && nyc report",
+      "test:coverage": "react-scripts test --coverage --watchAll=false && npm run cypress:run && node ./scripts/coverage-merge.js && nyc report",
       "lint": "eslint ./src ./cypress --ext .ts,.tsx",
       "lint:fix": "eslint ./src ./cypress --ext .ts,.tsx --fix",
       "stylelint": "stylelint '**/*.scss'",
       "stylelint:fix": "stylelint '**/*.scss' --fix",
-      "codebase:lint": "yarn lint && yarn stylelint",
-      "codebase:fix": "yarn lint:fix && yarn stylelint:fix",
+      "codebase:lint": "npm run lint && npm run stylelint",
+      "codebase:fix": "npm run lint:fix && npm run stylelint:fix",
       "cypress": "start-server-and-test start 3000 cypress:run",
       "cypress:run": "cypress run",
       "cypress:open": "cypress open"

--- a/template/.github/workflows/deploy.yml
+++ b/template/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install modules
-        run: yarn
+        run: npm ci
 
       - name: Build
-        run: yarn build
+        run: npm run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/template/.github/workflows/deploy_preview.yml
+++ b/template/.github/workflows/deploy_preview.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install modules
-        run: yarn
+        run: npm ci
 
       - name: Build
-        run: yarn build
+        run: npm run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/template/README.md
+++ b/template/README.md
@@ -6,40 +6,40 @@ This project was bootstrapped with [Nimble React template](https://github.com/ni
 
 In the project directory, you can run:
 
-`yarn start`: Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+`npm start`: Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-`yarn test`: Launches the test runner in the interactive watch mode. See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+`npm test`: Launches the test runner in the interactive watch mode. See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-`yarn test:coverage`: Both Unit Tests (Jest) and UI Tests (cypress) generate test coverage analytics. The below command runs all tests and merges both coverage files into a single report.
+`npm run test:coverage`: Both Unit Tests (Jest) and UI Tests (cypress) generate test coverage analytics. The below command runs all tests and merges both coverage files into a single report.
 
 > Use the `.nyc_output/out.json` artefact in your CI/CD pipeline to reuse the code coverage data.
 
-`yarn build`: Builds the app for production to the `build` folder. It correctly bundles React in production mode and
+`npm run build`: Builds the app for production to the `build` folder. It correctly bundles React in production mode and
 optimizes the build for the best performance. The build is minified and the filenames include the hashes. Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-`yarn eject`: If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This
+`npm run eject`: If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This
 command will remove the single build dependency from your project. Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them.
 All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them.
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
-`yarn lint`: Run ESLint in the project.
+`npm run lint`: Run ESLint in the project.
 
-`yarn lint:fix`: Fix auto-correctable ESLint errors in the project.
+`npm run lint:fix`: Fix auto-correctable ESLint errors in the project.
 
-`yarn stylelint`: Run Stylelint in the project.
+`npm run stylelint`: Run Stylelint in the project.
 
-`yarn stylelint:fix`: Fix auto-correctable Stylelint errors in the project.
+`npm run stylelint:fix`: Fix auto-correctable Stylelint errors in the project.
 
-`yarn codebase:lint`: Run ESLint and Stylelint together in the project.
+`npm run codebase:lint`: Run ESLint and Stylelint together in the project.
 
-`yarn codebase:fix`: Fix auto-correctable ESLint and Stylelint errors together in the project.
+`npm run codebase:fix`: Fix auto-correctable ESLint and Stylelint errors together in the project.
 
-`yarn cypress:run`: Runs Cypress tests to completion. By default, cypress run will run all tests headlessly in the Electron browser. [Check options](https://docs.cypress.io/guides/guides/command-line#cypress-run)
+`npm run cypress:run`: Runs Cypress tests to completion. By default, cypress run will run all tests headlessly in the Electron browser. [Check options](https://docs.cypress.io/guides/guides/command-line#cypress-run)
 
-`yarn cypress:open`: Opens the Cypress Test Runner. [Check options](https://docs.cypress.io/guides/guides/command-line#cypress-open)
+`npm run cypress:open`: Opens the Cypress Test Runner. [Check options](https://docs.cypress.io/guides/guides/command-line#cypress-open)
 
 ## Localization
 

--- a/template/gitignore
+++ b/template/gitignore
@@ -22,8 +22,6 @@
 .env.production.local
 
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
 
 # editors
 .vscode

--- a/template/public/index.html
+++ b/template/public/index.html
@@ -36,8 +36,8 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
+      To begin the development, run `npm start`.
+      To create a production bundle, use `npm run build`.
     -->
   </body>
 </html>


### PR DESCRIPTION
Closes https://github.com/nimblehq/react-templates/issues/66 

## What happened 👀

Use npm only, remove yarn from scripts and documentation.

## Insight 📝

While we could still keep the template commands with `yarn` (and then use npm), I have also removed `yarn` from this to prevent any confusion.

## Proof Of Work 📹

Test repository: https://github.com/malparty/npmreacttest/actions

|  All GitHub Actions run sucessfully | Project runs locally | Lint pass | Test pass |
|---|---|---|---|
|![image](https://user-images.githubusercontent.com/77609814/163095843-c75e0806-066b-48b7-be2e-2109caf92888.png)|![image](https://user-images.githubusercontent.com/77609814/163095913-62778588-ea51-43cc-886d-d55f72602a49.png)|![image](https://user-images.githubusercontent.com/77609814/163095956-69ab7424-abf7-40b2-8bca-7c22fece6441.png)|![image](https://user-images.githubusercontent.com/77609814/163096014-eca23729-9570-4253-a300-ea121180996c.png)|

