### PR TITLE
[#54] Migrate from @import to @use and @forward

### DIFF
--- a/template/.npmrc
+++ b/template/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/template/src/assets/stylesheets/_variables.scss
+++ b/template/src/assets/stylesheets/_variables.scss
@@ -1,0 +1,3 @@
+// dummy variables
+$bg-color: #282c34;
+$link-color: #61dafb;

--- a/template/src/assets/stylesheets/application.scss
+++ b/template/src/assets/stylesheets/application.scss
@@ -1,10 +1,10 @@
 // Variables
-@import 'variables';
+@forward 'src/assets/stylesheets/variables';
 
 // Dependencies
 
 // Functions
-@import 'functions/sizing';
+@forward 'src/assets/stylesheets/functions/sizing';
 
 // Mixins
 

--- a/template/src/dummy.scss
+++ b/template/src/dummy.scss
@@ -1,3 +1,5 @@
+@use 'src/assets/stylesheets/application' as app;
+
 body {
   margin: 0;
 
@@ -36,14 +38,14 @@ code {
   justify-content: center;
   min-height: 100vh;
 
-  background-color: #282c34;
+  background-color: app.$bg-color;
 
   color: #fff;
-  font-size: calc(10px + 2vmin);
+  font-size: calc(#{app.rem(10px)} + 2vmin);
 }
 
 .app-link {
-  color: #61dafb;
+  color: app.$link-color;
 }
 
 @keyframes app-logo-spin {

--- a/template/src/dummy.scss
+++ b/template/src/dummy.scss
@@ -1,4 +1,4 @@
-@use 'src/assets/stylesheets/application' as app;
+@use 'src/assets/stylesheets/application';
 
 body {
   margin: 0;
@@ -38,14 +38,14 @@ code {
   justify-content: center;
   min-height: 100vh;
 
-  background-color: app.$bg-color;
+  background-color: application.$bg-color;
 
   color: #fff;
-  font-size: calc(#{app.rem(10px)} + 2vmin);
+  font-size: calc(#{application.rem(10px)} + 2vmin);
 }
 
 .app-link {
-  color: app.$link-color;
+  color: application.$link-color;
 }
 
 @keyframes app-logo-spin {


### PR DESCRIPTION
Resolves https://github.com/nimblehq/react-templates/issues/54

## What happened 👀

- Use [`@use`](https://sass-lang.com/documentation/at-rules/use) and [`@forward`](https://sass-lang.com/documentation/at-rules/forward) instead of [`@import`](https://sass-lang.com/documentation/at-rules/import) as it is going to be replicated
- Demonstrate the usage on the `dummy.scss` file which is the default style for the default React home page

## Insight 📝

N/A

## Proof Of Work 📹

Generate a new app and run

```javascript
npx create-react-app my-app --template file:./
cd my-app
npm start
```

The home page still has the same look as before

![Screen Shot 2565-05-24 at 16 54 02](https://user-images.githubusercontent.com/1772999/170005440-34506908-c2bf-4001-bbdd-8a7c696e246d.png)
