### PR TITLE
[#58] Add a Github workflow to publish the package to the NPM registry

### DIFF
--- a/template/.github/workflows/publish.yml
+++ b/template/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish package to npmjs
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish package
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish package to npmjs
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Resolves https://github.com/nimblehq/react-templates/issues/58

## What happened 👀

Add the `publish` workflow to publish the package to the NPM registry

## Insight 📝

- We did it in [infrastructure-templates](https://github.com/nimblehq/infrastructure-templates/actions/runs/2407351174)
- We need to add `NPM_TOKEN` into Github actions secrets

## Proof Of Work 📹

It worked in [infrastructure-templates](https://github.com/nimblehq/infrastructure-templates/actions/runs/2407351174)
