### PR TITLE
[#109] Update PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-https://github.com/nimblehq/react-templates/issues/?
+https://github.com/nimblehq/react-templates/issues/??
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+Provide a description of the **changes** this pull request brings to the codebase. Additionally, when the pull request is still being worked on, a checklist of the planned changes is welcome to track progress.
 
 ## Insight 📝
 
-Describe in detail how to test the changes. Referenced documentation is welcome as well.
+Describe in detail why this solution is the most appropriate, which solution you tried but did not go with, and how to test the changes. References to relevant documentation are welcome as well.
 
 ## Proof Of Work 📹
 
-Show us the implementation: screenshots, GIF, etc. P.S. Maximum details possible
+Show us the implementation: screenshots, GIFs, etc.

--- a/packages/cra-template/template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/packages/cra-template/template/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-https://github.com/nimblehq/{YOUR_REPOSITORY}/issues/?
+https://github.com/nimblehq/{YOUR_REPOSITORY}/issues/??
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+Provide a description of the **changes** this pull request brings to the codebase. Additionally, when the pull request is still being worked on, a checklist of the planned changes is welcome to track progress.
 
 ## Insight 📝
 
-Describe in detail how to test the changes. Referenced documentation is welcome as well.
+Describe in detail why this solution is the most appropriate, which solution you tried but did not go with, and how to test the changes. References to relevant documentation are welcome as well.
 
 ## Proof Of Work 📹
 
-Show us the implementation: screenshots, GIF, etc. P.S. Maximum details possible
+Show us the implementation: screenshots, GIFs, etc.

--- a/packages/cra-template/template/.gitlab/merge_request_templates/Default.md
+++ b/packages/cra-template/template/.gitlab/merge_request_templates/Default.md
@@ -2,11 +2,11 @@
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+Provide a description of the **changes** this pull request brings to the codebase. Additionally, when the pull request is still being worked on, a checklist of the planned changes is welcome to track progress.
 
 ## Insight 📝
 
-Describe in detail how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
+Describe in detail why this solution is the most appropriate, which solution you tried but did not go with, and how to test the changes. References to relevant documentation are welcome as well.
 
 ## Proof Of Work 📹
 


### PR DESCRIPTION
- Close #109

## What happened 👀

Update the 2 PR templates (GitHub and GitLab) according to [this change](https://github.com/nimblehq/git-template/pull/27).

## Insight 📝

n/a

## Proof Of Work 📹

| GitHub | GitLab |
|---|---|
|![image](https://user-images.githubusercontent.com/77609814/177966834-fb5269f0-a6aa-4f9b-a994-bb1542fc3c37.png)|![image](https://user-images.githubusercontent.com/77609814/177966802-a596dff3-94c7-4e73-86c8-06816fd7d05b.png)|
