### PR TITLE
[#125] Improve github workflow

### DIFF
--- a/.github/workflows/test-cli-tool.yml
+++ b/.github/workflows/test-cli-tool.yml
@@ -11,15 +11,15 @@ jobs:
         node: [16]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"

--- a/.github/workflows/test-cra-template.yml
+++ b/.github/workflows/test-cra-template.yml
@@ -11,15 +11,15 @@ jobs:
         node: [14, 16]
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'

--- a/packages/cra-template/template/.github/workflows/deploy.yml
+++ b/packages/cra-template/template/.github/workflows/deploy.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci

--- a/packages/cra-template/template/.github/workflows/deploy.yml
+++ b/packages/cra-template/template/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Netlify
 
 on:
   push:
-    branches: ['main', 'master']
+    branches: ['main']
   workflow_dispatch:
     inputs:
       deploy-msg:
@@ -12,14 +12,15 @@ on:
 jobs:
   deploy:
     name: Build and Deploy to Netlify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Install modules
         run: npm ci

--- a/packages/cra-template/template/.github/workflows/deploy_preview.yml
+++ b/packages/cra-template/template/.github/workflows/deploy_preview.yml
@@ -5,14 +5,15 @@ on: [pull_request, workflow_dispatch]
 jobs:
   deploy-preview:
     name: Build and Deploy preview on Netlify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Install modules
         run: npm ci

--- a/packages/cra-template/template/.github/workflows/deploy_preview.yml
+++ b/packages/cra-template/template/.github/workflows/deploy_preview.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci

--- a/packages/cra-template/template/.github/workflows/test.yml
+++ b/packages/cra-template/template/.github/workflows/test.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'


### PR DESCRIPTION
Close https://github.com/nimblehq/react-templates/issues/125

## What happened 👀

- Some steps are missing the step name
- Remove branch master as I think we always go with main for all the projects
- Update ubuntu on deployment workflow to use ubuntu-latest, with this we could avoid a deprecated environment message.

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/runner-images/issues/6002

I think it should be fine since we're testing with ubuntu latest as well 🤔

## Insight 📝

`N/A`

## Proof Of Work 📹

`N/A`
