### PR TITLE
[#130] Fix: [Bootstrap Add-on] Compilation errors

### DIFF
--- a/packages/cli-tool/src/add-ons/ui-framework/bootstrap.ts
+++ b/packages/cli-tool/src/add-ons/ui-framework/bootstrap.ts
@@ -8,7 +8,7 @@ import {
   lineFinderFuncType,
 } from '../../helpers/file-editor';
 
-const DEV_DEPENDENCIES = ['bootstrap@^5.1.3'];
+const DEV_DEPENDENCIES = ['bootstrap@5.2.1'];
 
 export const addBootstrapFileStructure = (appPath: string): Promise<void> => {
   return new Promise((resolve, reject) => {

--- a/packages/cra-template/template/.add-ons/bootstrap/index.scss
+++ b/packages/cra-template/template/.add-ons/bootstrap/index.scss
@@ -1,6 +1,7 @@
 // Configuration
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/maps';
 @import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';
 

--- a/packages/cra-template/template/src/assets/stylesheets/functions/_sizing.scss
+++ b/packages/cra-template/template/src/assets/stylesheets/functions/_sizing.scss
@@ -5,7 +5,7 @@
     @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
-      $em-value: ($value / $base-font-size) + em;
+      $em-value: calc($value / $base-font-size) + em;
       $list: append($list, $em-value);
     }
   }
@@ -20,7 +20,7 @@
     @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
-      $rem-value: ($value / $base-font-size) + rem;
+      $rem-value: calc($value / $base-font-size) + rem;
       $list: append($list, $rem-value);
     }
   }


### PR DESCRIPTION
Close https://github.com/nimblehq/react-templates/issues/130

## What happened 👀

When creating the Bootstrap application from the template, the app fails to compile.

## Insight 📝

On the created application, Bootstrap 5.2 is installed and then causes errors. So here I:

- Lock the Bootstrap version (Now moved to the latest 5.2.1).
- Fix the Bootstrap 5.2 errors that used to be warned. (as listed in the issue)

## Proof Of Work 📹

Right now the app starts successfully:

<img src="https://user-images.githubusercontent.com/6965195/189277210-0b3c0afd-d086-4b2d-be64-3f5c20e5932f.png" width="300"/>
