### PR TITLE
[#153] Fix: CI failing on development branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Closes https://github.com/nimblehq/react-templates/issues/??
+- Close #
 
 ## What happened 👀
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/react-templates/issues/??
+Closes https://github.com/nimblehq/react-templates/issues/??
 
 ## What happened 👀
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <strong>React Templates</strong>
 </p>
 
-
 ---
 
 <p align="center">

--- a/packages/cli-tool/test/commands/generate/index.test.ts
+++ b/packages/cli-tool/test/commands/generate/index.test.ts
@@ -9,7 +9,7 @@ import { gitHubTestData, gitLabTestData, noVersionControlTestData } from '../../
 import { TestScenario } from '../../helpers/test-scenario';
 
 const craTemplateReference = `file:./react-templates/packages/cra-template`;
-const viteTemplateReference = 'feature/gh88-replace-webpack-with-vite';
+const viteTemplateReference = '52288d1e5e560bcc717f760f1fd19f7cb1b0085e';
 const projectName = 'test-app';
 const testFolderPath = '../../../';
 

--- a/packages/cli-tool/test/commands/generate/index.test.ts
+++ b/packages/cli-tool/test/commands/generate/index.test.ts
@@ -9,7 +9,7 @@ import { gitHubTestData, gitLabTestData, noVersionControlTestData } from '../../
 import { TestScenario } from '../../helpers/test-scenario';
 
 const craTemplateReference = `file:./react-templates/packages/cra-template`;
-// TODO: Adjust viteTemplateReferencne to not use commit hash of development branch for vite template
+// TODO: Adjust viteTemplateReference to use commit hash of development branch for vite template
 // https://github.com/nimblehq/react-templates/commit/52288d1e5e560bcc717f760f1fd19f7cb1b0085e
 const viteTemplateReference = '52288d1e5e560bcc717f760f1fd19f7cb1b0085e';
 const projectName = 'test-app';

--- a/packages/cli-tool/test/commands/generate/index.test.ts
+++ b/packages/cli-tool/test/commands/generate/index.test.ts
@@ -9,6 +9,8 @@ import { gitHubTestData, gitLabTestData, noVersionControlTestData } from '../../
 import { TestScenario } from '../../helpers/test-scenario';
 
 const craTemplateReference = `file:./react-templates/packages/cra-template`;
+// TODO: Adjust viteTemplateReferencne to not use commit hash of development branch for vite template
+// https://github.com/nimblehq/react-templates/commit/52288d1e5e560bcc717f760f1fd19f7cb1b0085e
 const viteTemplateReference = '52288d1e5e560bcc717f760f1fd19f7cb1b0085e';
 const projectName = 'test-app';
 const testFolderPath = '../../../';

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -15,6 +15,7 @@
       "@nimblehq/eslint-config-nimble-react": "^1.0.0",
       "@nimblehq/stylelint-config-nimble": "^1.0.0",
       "@testing-library/cypress": "8.0.2",
+      "@testing-library/dom": "^8.20.0",
       "@testing-library/jest-dom": "5.16.4",
       "@testing-library/react": "13.1.1",
       "@testing-library/user-event": "14.1.1",

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -15,7 +15,7 @@
       "@nimblehq/eslint-config-nimble-react": "^1.0.0",
       "@nimblehq/stylelint-config-nimble": "^1.0.0",
       "@testing-library/cypress": "8.0.2",
-      "@testing-library/dom": "^8.20.0",
+      "@testing-library/dom": "8.20.0",
       "@testing-library/jest-dom": "5.16.4",
       "@testing-library/react": "13.1.1",
       "@testing-library/user-event": "14.1.1",


### PR DESCRIPTION
Closes https://github.com/nimblehq/react-templates/issues/153

## What happened 👀

✅ Currently, we fixed the CI by adjusting the template reference to the commit hash on the develop branch that has the vite-template folder.

✅ `@testlng-library/dom` made a 9.0.0 release which is causing issues with our current versions of packages when generating a new project and causing the tests to fail for the CRA template.
We would need to upgrade all the testing library packages to make it work. For now, we're fixing the `@testlng-library/dom` to 8.2.0 (the previous version) to ensure the CI passes on runs and update those packages in a separate PR

## Insight 📝

Previously, we were using the `feature/gh88-replace-webpack-with-vite` branch to download the repository to extract and copy over the template files. 
We need documentation about how we update the template to ensure there aren't any CI issues for new changes (after merging).

## Proof Of Work 📹

CI passes 🍏 
