### PR TITLE
[#165] Fix: The sample test case HomeScreen > renders learn react link runs failed

### DIFF
--- a/packages/cra-template/template/src/setupTests.ts
+++ b/packages/cra-template/template/src/setupTests.ts
@@ -3,7 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
-import { configure } from '@testing-library/dom';
+import { configure } from '@testing-library/react';
 
 configure({
   testIdAttribute: 'data-test-id',


### PR DESCRIPTION
- Close #165

## What happened 👀

Use `configure` from `@testing-library/react` instead.

## Insight 📝

- The custom `testIdAttribute: 'data-test-id'` is ignored somehow when running the unit test. (It works well in UI test)
`TestingLibraryElementError: Unable to find an element by: [data-testid="app-link"]`
- Maybe the `@testing-library/dom`'s version and `@testing-library/react`'s version are not the same and React ignore all custom attributes from `@testing-library/dom`. [Ref](https://github.com/testing-library/dom-testing-library/issues/874)

## Proof Of Work 📹

- Use `cli-tool` locally to generate a new app with local changes by running the commands:
```
 $ cd ./packages/cli-tool/
 $ npm i
 $ ./bin/dev generate app-name ~/{react-templates_path}/ file:react-templates/packages/cra-template
```
All the tests passed!~
![image](https://github.com/nimblehq/react-templates/assets/60863885/6672f6d7-984a-4cf1-8e5b-d7ba08ca79b7)

